### PR TITLE
Fix type errors in use-mouse-position and update animation options

### DIFF
--- a/src/fancy/components/text/vertical-cut-reveal.tsx
+++ b/src/fancy/components/text/vertical-cut-reveal.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { AnimationOptions, motion } from "motion/react"
 import {
   forwardRef,
   useCallback,
@@ -9,14 +10,13 @@ import {
   useRef,
   useState,
 } from "react"
-import { DynamicAnimationOptions, motion } from "motion/react"
 
 import { cn } from "@/lib/utils"
 
 interface TextProps {
   children: React.ReactNode
   reverse?: boolean
-  transition?: DynamicAnimationOptions
+  transition?: AnimationOptions
   splitBy?: "words" | "characters" | "lines" | string
   staggerDuration?: number
   staggerFrom?: "first" | "last" | "center" | "random" | number

--- a/src/hooks/use-mouse-position.ts
+++ b/src/hooks/use-mouse-position.ts
@@ -1,7 +1,7 @@
 import { RefObject, useEffect, useState } from "react"
 
 export const useMousePosition = (
-  containerRef?: RefObject<HTMLElement | SVGElement>
+  containerRef?: RefObject<HTMLElement | SVGElement | null>
 ) => {
   const [position, setPosition] = useState({ x: 0, y: 0 })
 


### PR DESCRIPTION
Added null as a possible type for containerRef in use-mouse-position.ts

Replaced DynamicAnimationOptions with AnimationOptions (the correct type from motion/react)

These changes fix build errors that occurred during deployment on Vercel