### PR TITLE
Fix missing React key prop in TextRotate component

### DIFF
--- a/src/fancy/components/text/text-rotate.tsx
+++ b/src/fancy/components/text/text-rotate.tsx
@@ -399,7 +399,10 @@ const TextRotate = forwardRef<TextRotateRef, TextRotateProps>(
                     const totalIndex = previousCharsCount + charIndex
                     const animationProps = getAnimationProps(totalIndex)
                     return (
-                      <span className={cn(elementLevelClassName)}>
+                      <span 
+                      key={totalIndex}
+                      className={cn(elementLevelClassName)}
+                      >
                         <motion.span
                           {...animationProps}
                           key={charIndex}


### PR DESCRIPTION
### Files Changed
- modified: src/fancy/components/text/text-rotate.tsx

### Issue 
So I was modifying the landing page for my school project using your awesome component library, I encountered a React error when using the [Text Rotate](https://www.fancycomponents.dev/docs/components/text/text-rotate) component  similar to the first Demo with the orange background.

![Screenshot 2025-05-14 124102](https://github.com/user-attachments/assets/26281df0-2edf-4e7a-8645-e5d1062ba0d2)
___________________

Vercel build was also failing for this too :

![Screenshot 2025-05-14 192308](https://github.com/user-attachments/assets/2ceb23b7-3616-464d-9f61-7acd54362d40)

### Code
The problem shows that each child should have a unique key around line @ 376, and while that inner span already had a key, the key was actually needed for the `span` element around what was line @ 402.

### Fix
What I did: It was actually a simple key missing problem! I used the `totalIndex` as the key for that span element, and it solves the problem.

