### PR TITLE
docs: Add shadcn init and @fancy registry to installation docs

### DIFF
--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -21,6 +21,23 @@ You have two options to add a component to your project:
 
 ### Using the CLI
 
+If your project does not already have a `components.json`, initialize shadcn first:
+
+<InstallTabs command="shadcn@latest init" npx />
+
+Then add the `@fancy` registry to the existing `registries` field in your `components.json`:
+
+<CodeSnippet title="components.json">
+```json
+{
+  // ...
+  "registries": {
+    "@fancy": "https://fancycomponents.dev/r/{name}.json"
+  }
+}
+```
+</CodeSnippet>
+
 To add a component using the CLI, you need to run the following command in your terminal:
 
 <InstallTabs command="shadcn add @fancy/component-name" npx />


### PR DESCRIPTION
Fixes #66 , the modified URL is https://www.fancycomponents.dev/docs/installation

Add instructions to initialize shadcn when a project lacks components.json and show how to add the `@fancy` registry to the `registries` field in components.json.

The part highlighted with the red box is the added section.

<img width="536" height="569" alt="image" src="https://github.com/user-attachments/assets/9370e68e-f92e-4844-9b36-098086e5e4aa" />

What it looked like before modification

<img width="513" height="286" alt="image" src="https://github.com/user-attachments/assets/44df441b-39db-4972-a1aa-ac7600143f87" />
